### PR TITLE
pims 0.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,12 +23,8 @@ requirements:
     - python
     - imageio
     - numpy >=1.19
+    - packaging
     - slicerator >=0.9.8
-# The following dependencies are only required for rich IPython display
-    - jinja2
-    - pillow
-# The following dependencies are optional (for specific readers)
-    - matplotlib-base  # one of { scikit-image | matplotlib-base }
     - tifffile
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "PIMS" %}
-{% set version = "0.6.1" %}
+{% set version = "0.7" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e2b704461d4ea9bce8b6a22ca35836fe67d6d34537736b405341ae5547194f3b
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
+  sha256: 55907a4c301256086d2aa4e34a5361b9109f24e375c2071e1117b9491e82946b
 
 build:
   number: 0


### PR DESCRIPTION
### Links

- [PKG-7008](https://anaconda.atlassian.net/browse/PKG-7008)
- [Upstream repository](https://github.com/soft-matter/pims/tree/v0.7)
- [Upstream changelog/diff](https://github.com/soft-matter/pims/releases)
- Relevant dependency PRs:
  - Needed update to fix `ImportError: cannot import name 'Iterable' from 'collections'` for `dask-image`

### Explanation of changes:

- Update version and sha
- Update source url
- Update dependencies

[PKG-7008]: https://anaconda.atlassian.net/browse/PKG-7008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ